### PR TITLE
Fix objects in storage being affected from outside changes

### DIFF
--- a/src/apis/storage.ts
+++ b/src/apis/storage.ts
@@ -6,7 +6,7 @@ const makeStorage = (): any => {
   return {
     async get(key: any): Promise<any> {
       if (!key) {
-        return _storage;
+        return JSON.parse(JSON.stringify(_storage));
       }
       const result: {
         [key: string]: string;
@@ -29,17 +29,17 @@ const makeStorage = (): any => {
       } else {
         result[key] = _storage[key];
       }
-      return result;
+      return JSON.parse(JSON.stringify(result));
     },
 
     async set(key: any, value: any): Promise<any> {
       if (typeof key === 'object') {
         // TODO support nested objects
         Object.keys(key).map(oKey => {
-          _storage[oKey] = key[oKey];
+          _storage[oKey] = JSON.parse(JSON.stringify(key[oKey]));
         });
       } else {
-        _storage[key] = value;
+        _storage[key] = JSON.parse(JSON.stringify(value));
       }
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,9 +82,19 @@ export interface RuntimeFake extends Runtime {
 }
 
 export interface StorageFake extends Storage {
-  _get(key: any): Promise<any>;
-  _set(key: any, value: any): Promise<any>;
-  _remove(key: any): Promise<any>;
+  StorageArea: {
+    clear: sinon.SinonStub;
+    get: sinon.SinonStub;
+    getBytesInUse?: sinon.SinonStub;
+    remove: sinon.SinonStub;
+    set: sinon.SinonStub;
+    _get(key: any): Promise<any>;
+    _set(key: any, value: any): Promise<any>;
+    _remove(key: any): Promise<any>;
+  };
+  local: StorageFake['StorageArea'];
+  managed: StorageFake['StorageArea'];
+  sync: StorageFake['StorageArea'];
 }
 
 export interface TabsFake extends Tabs {


### PR DESCRIPTION
- make a deep clone then setting and getting objects from the fake storage
- fix the `StorageFake` type: the `_get`/`_set`/`_remove` helper functions there incorrectly defined on `browser.storage`, and not `browser.storage.local`